### PR TITLE
Add behaviour on hover

### DIFF
--- a/assets/icons/slider__arrow--left.svg
+++ b/assets/icons/slider__arrow--left.svg
@@ -1,3 +1,3 @@
 <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M13.5 7H1M1 7L7 1M1 7L7 13" stroke="white" stroke-opacity="0.4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M13.5 7H1M1 7L7 1M1 7L7 13" stroke="white" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/assets/styles/card.css
+++ b/assets/styles/card.css
@@ -32,10 +32,12 @@
     -webkit-line-clamp: 2;
     line-clamp: 2;
     -webkit-box-orient: vertical;
-
 }
 
 /* Hover */
+.card:hover .header-3 {
+    transition: color 0.5s ease-in-out;
+}
 
 .card:hover .header-3 {
     color: var(--primary);

--- a/assets/styles/card.css
+++ b/assets/styles/card.css
@@ -7,6 +7,13 @@
 
     background-color: var(--white);
     border-radius: 20px;
+    overflow: hidden;
+
+    cursor: pointer;
+}
+
+.card__img-holder {
+    background-color: var(--content-bg);
 }
 
 .card__content {
@@ -19,4 +26,17 @@
 
 .card__content > .header-3 {
     text-align: left;
+    overflow: hidden;
+    display: -webkit-box;
+    word-break: keep-all;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+
+}
+
+/* Hover */
+
+.card:hover .header-3 {
+    color: var(--primary);
 }

--- a/assets/styles/cta-btn.css
+++ b/assets/styles/cta-btn.css
@@ -13,6 +13,8 @@
     border-width: 0px;
 
     background-color: var(--dark);
+
+    cursor: pointer;
 }
 
 /* Behaviour on hover*/

--- a/assets/styles/cta-btn.css
+++ b/assets/styles/cta-btn.css
@@ -19,6 +19,14 @@
 
 /* Behaviour on hover*/
 
+.cta-btn {
+    transition: background-color 0.5s ease-in-out;
+}
+
+.cta-btn > .action-small {
+    transition: color 0.5s ease-in-out;
+}
+
 .cta-btn:hover {
     background-color: var(--white);
 }

--- a/assets/styles/cta-btn.css
+++ b/assets/styles/cta-btn.css
@@ -14,3 +14,13 @@
 
     background-color: var(--dark);
 }
+
+/* Behaviour on hover*/
+
+.cta-btn:hover {
+    background-color: var(--white);
+}
+
+.cta-btn:hover > .action-small {
+    color: var(--dark);
+}

--- a/assets/styles/footer.css
+++ b/assets/styles/footer.css
@@ -13,20 +13,29 @@
     display: flex;
     gap: 12px;
 
+    width: 1276px;
+
 }
 
 .footer__contacts-item {
-    width: 417px;
     height: 204px;
+
+    flex-grow: 1;
+
+    border-radius: 20px;
+    background-color: var(--content-bg);
+}
+
+.footer__contacts-link {
+    display: block;
+    width: 100%;
+    height: 100%;
     padding: 20px;
 
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: 12px;
-
-    border-radius: 20px;
-    background-color: var(--content-bg);
 }
 
 .footer__bottom {
@@ -44,4 +53,14 @@
 
 .footer__social-item {
     padding: 8px;
+}
+
+/* Hover */
+
+.footer__contacts-link:hover > .footer__contact  > .action-large {
+    color: var(--primary);
+}
+
+.footer__contacts-link:hover > .header-3 {
+    color: var(--primary);
 }

--- a/assets/styles/header.css
+++ b/assets/styles/header.css
@@ -46,7 +46,12 @@ header {
     border-radius: 12px;
 }
 
+/* Behaviour on hover */
+
 .navbar__link:hover {
     background-color: var(--primary10);
+}
+
+.navbar__link:hover > .action-small {
     color: var(--primary);
 }

--- a/assets/styles/header.css
+++ b/assets/styles/header.css
@@ -48,6 +48,14 @@ header {
 
 /* Behaviour on hover */
 
+.navbar__link{
+    transition: background-color 0.4s ease-in-out;
+}
+
+.navbar__link > .action-small {
+    transition: color 0.4s ease-in-out;
+}
+
 .navbar__link:hover {
     background-color: var(--primary10);
 }

--- a/assets/styles/slider-section.css
+++ b/assets/styles/slider-section.css
@@ -81,6 +81,14 @@
 
 /* Hover */
 
+.slider__btn {
+    transition: background-color 0.5s ease-in-out;
+}
+
+.slider__btn path {
+    transition: stroke 0.5s ease-in-out;
+}
+
 .slider__btn:hover {
     background-color: var(--white);
 }

--- a/assets/styles/slider-section.css
+++ b/assets/styles/slider-section.css
@@ -70,6 +70,10 @@
     width: 50%;
 }
 
-.slider__btn--left {
-    border-color: var(--white40);
+/* Hover */
+
+/* Active */
+
+.slider__btn--inactive {
+    opacity: 0.4;
 }

--- a/assets/styles/slider-section.css
+++ b/assets/styles/slider-section.css
@@ -55,6 +55,8 @@
     background-color: transparent;
     border: 1px solid var(--white);
     border-radius: 20px;
+
+    cursor: pointer;
 }
 
 .slider__arrow-holder {
@@ -70,10 +72,29 @@
     width: 50%;
 }
 
-/* Hover */
-
-/* Active */
+/* Inactive state */
 
 .slider__btn--inactive {
     opacity: 0.4;
+    cursor: unset;
+}
+
+/* Hover */
+
+.slider__btn:hover {
+    background-color: var(--white);
+}
+
+.slider__btn:hover path {
+    stroke: var(--primary);
+}
+
+/* Disable hover effects for the inactive state*/
+
+.slider__btn--inactive:hover {
+    background-color: unset;
+}
+
+.slider__btn--inactive:hover path {
+    stroke: var(--white);
 }

--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@
                     </div>
                 </div>
                 <div class="slider__btn-holder">
-                    <button class="slider__btn slider__btn--left">
+                    <button class="slider__btn slider__btn--left slider__btn--inactive">
                         <div class="slider__arrow-holder">
                             <img src="assets/icons/slider__arrow--left.svg" alt="Arrow pointing to the left"
                                 class="slider__arrow slider__arrow--left">

--- a/index.html
+++ b/index.html
@@ -139,14 +139,16 @@
                 <div class="slider__btn-holder">
                     <button class="slider__btn slider__btn--left slider__btn--inactive">
                         <div class="slider__arrow-holder">
-                            <img src="assets/icons/slider__arrow--left.svg" alt="Arrow pointing to the left"
-                                class="slider__arrow slider__arrow--left">
+                            <svg class="slider__arrow slider__arrow--left" width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <path d="M13.5 7H1M1 7L7 1M1 7L7 13" stroke="white" stroke-linecap="round" stroke-linejoin="round"/>
+                                </svg>
                         </div>
                     </button>
                     <button class="slider__btn slider__btn--right">
                         <div class="slider__arrow-holder">
-                            <img src="assets/icons/slider__arrow--right.svg" alt="Arrow pointing to the right"
-                                class="slider__arrow slider__arrow--right">
+                            <svg class="slider__arrow slider__arrow--right"  width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <path d="M1 7H13.5M13.5 7L7.5 1M13.5 7L7.5 13" stroke="white" stroke-linecap="round" stroke-linejoin="round"/>
+                                </svg>
                         </div>
                     </button>
                 </div>
@@ -211,7 +213,7 @@
                                 <h4 class="header-4__text header-4--harmony">For harmony</h4>
                             </div>
                             <div class="header-3">
-                                <h3 class="header-3__text">Spontaneous Coding Philosopher</h3>
+                                <h3 class="header-3__text">Spontaneous Coding Philosopher Spontaneous Coding Philosopher</h3>
                             </div>
                         </div>
                     </div>
@@ -275,14 +277,13 @@
         <div class="footer__container">
             <ul class="footer__contacts-holder">
                 <li class="footer__contacts-item">
-                    <a href="" class="footer__contacts-link">
+                    <a href="tel:+375291112233" target="_blank" class="footer__contacts-link">
                         <div class="footer__contacts-icon-holder">
                             <img src="assets/icons/footer__contact-icon--1.svg" alt="An image of Santa"
                                 class="footer__contact-icon footer__contact-icon--1">
                         </div>
                         <div class="footer__contact">
-                            <p class="action-large"><a href="tel:+375291112233" target="_blank">+375 (29)
-                                    111-22-33</a></p>
+                            <p class="action-large">+375 (29)111-22-33</p>
                         </div>
                         <div class="header-3">
                             <h3 class="header-3__text">Call Us</h3>
@@ -290,15 +291,14 @@
                     </a>
                 </li>
                 <li class="footer__contacts-item">
-                    <a href="" class="footer__contacts-link">
+                    <a href="https://maps.app.goo.gl/xhryvRq5jTzidotE8" class="footer__contacts-link">
                         <div class="footer__contacts-icon-holder">
                             <img src="assets/icons/footer__contact-icon--2.svg"
                                 alt="An image of a dancing Christmas tree"
                                 class="footer__contact-icon footer__contact-icon--2">
                         </div>
                         <div class="footer__contact">
-                            <p class="action-large"><a href="https://maps.app.goo.gl/xhryvRq5jTzidotE8"
-                                    target="_blank">Magic forest</a></p>
+                            <p class="action-large">Magic forest</p>
                         </div>
                         <div class="header-3">
                             <h3 class="header-3__text">Meet us</h3>
@@ -306,14 +306,13 @@
                     </a>
                 </li>
                 <li class="footer__contacts-item">
-                    <a href="" class="footer__contacts-link">
+                    <a href="mailto:gifts@magic.com"  target="_blank" class="footer__contacts-link">
                         <div class="footer__contacts-icon-holder">
                             <img src="assets/icons/footer__contact-icon--3.svg" alt="An image of a snake"
                                 class="footer__contact-icon footer__contact-icon--3">
                         </div>
                         <div class="footer__contact">
-                            <p class="action-large"><a href="mailto:gifts@magic.com" target="_blank">gifts@magic.com</a>
-                            </p>
+                            <p class="action-large">gifts@magic.com</p>
                         </div>
                         <div class="header-3">
                             <h3 class="header-3__text">Write to us</h3>


### PR DESCRIPTION
### 1) Links

deploy: [here](https://taorkon.github.io/christmas-shop/)
figma: [here](https://www.figma.com/design/jenz4CWGffNEOCplzN4Qwg/Christmas-Shop-(Copy)?node-id=3-600&node-type=frame&t=B8RQCT6SCZJTP9Xu-0)
task : [here](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/christmas-shop/christmas-shop-part1.md)

### 2) Text ellipsis

I need ellipsis on 2nd line:
![IMG_20241204_143216_477](https://github.com/user-attachments/assets/89a97c50-0319-477a-a134-c738b5788f19)

`text-overflow: ellipsis` only allows one row

My code doesn't break it the way it should, and it's not cross-browser (see [card.css](https://github.com/taorkon/christmas-shop/blob/layout-hover/assets/styles/card.css))

`.card__content > .header-3 {`
`    text-align: left;`
`    overflow: hidden;`
`    display: -webkit-box;`
`    word-break: keep-all;`
`    -webkit-line-clamp: 2;`
`    line-clamp: 2;`
`    -webkit-box-orient: vertical;`
`}`

![IMG_20241204_143216_298](https://github.com/user-attachments/assets/6236e9ff-408b-45ae-bb5b-5799ae2a3b49)

Do you know if there is a better solution?

